### PR TITLE
feat: add neon music key detector

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
-# codex_bpm_analyzer
+# Neon Key Detector
+
+A vanilla JavaScript web application that analyzes an uploaded audio file and estimates the distribution of musical keys throughout the track. It visualizes key percentages with a glowing bar chart and an animated neon waveform synced to playback.
+
+## Features
+- Upload audio files (`.mp3`, `.wav`, etc.).
+- Detects percentage of each major and minor key using the Web Audio API.
+- Highlights the most prominent key.
+- Animated canvas visualizer with a purple neon theme.
+- Reset button clears results and allows a new upload.
+
+Open `index.html` in a modern browser to use the app.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Neon Key Detector</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="container">
+    <h1>Music Key Detector</h1>
+    <input type="file" id="audioFile" accept="audio/*" />
+    <canvas id="visualizer"></canvas>
+    <div id="results"></div>
+    <button id="resetButton">Reset</button>
+    <audio id="audio" controls></audio>
+  </div>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,181 @@
+const fileInput = document.getElementById('audioFile');
+const audio = document.getElementById('audio');
+const resultsDiv = document.getElementById('results');
+const resetButton = document.getElementById('resetButton');
+const canvas = document.getElementById('visualizer');
+const ctx = canvas.getContext('2d');
+
+let audioCtx; let source; let analyser; let animationId;
+let pitchHistogram = new Array(12).fill(0);
+
+const noteNames = ['C','C#','D','D#','E','F','F#','G','G#','A','A#','B'];
+const majorProfile = [6.35, 2.23, 3.48, 2.33, 4.38, 4.09, 2.52, 5.19, 2.39, 3.66, 2.29, 2.88];
+const minorProfile = [6.33, 2.68, 3.52, 5.38, 2.60, 3.53, 2.54, 4.75, 3.98, 2.69, 3.34, 3.17];
+
+fileInput.addEventListener('change', handleFiles);
+audio.addEventListener('play', startVisualizer);
+audio.addEventListener('pause', stopVisualizer);
+resetButton.addEventListener('click', resetAll);
+
+function handleFiles() {
+  const file = fileInput.files[0];
+  if (!file) return;
+  const url = URL.createObjectURL(file);
+  audio.src = url;
+  analyzeKey(file);
+}
+
+function analyzeKey(file) {
+  const reader = new FileReader();
+  reader.onload = async (e) => {
+    const arrayBuffer = e.target.result;
+    if (!audioCtx) audioCtx = new (window.AudioContext || window.webkitAudioContext)();
+    const audioBuffer = await audioCtx.decodeAudioData(arrayBuffer);
+    pitchHistogram = computePitchHistogram(audioBuffer);
+    const keyScores = detectKeys(pitchHistogram);
+    displayResults(keyScores);
+  };
+  reader.readAsArrayBuffer(file);
+}
+
+function computePitchHistogram(audioBuffer) {
+  const data = audioBuffer.getChannelData(0);
+  const sampleRate = audioBuffer.sampleRate;
+  const step = 2048;
+  const hist = new Array(12).fill(0);
+  for (let i = 0; i < data.length - step; i += step) {
+    const slice = data.slice(i, i + step);
+    const freq = autoCorrelate(slice, sampleRate);
+    if (freq) {
+      const midi = 69 + 12 * Math.log2(freq / 440);
+      const pitchClass = ((Math.round(midi) % 12) + 12) % 12;
+      hist[pitchClass]++;
+    }
+  }
+  return hist;
+}
+
+function autoCorrelate(buf, sampleRate) {
+  const SIZE = buf.length;
+  const MAX_SAMPLES = Math.floor(SIZE / 2);
+  let bestOffset = -1;
+  let bestCorrelation = 0;
+  let rms = 0;
+  for (let i = 0; i < SIZE; i++) {
+    const val = buf[i];
+    rms += val * val;
+  }
+  rms = Math.sqrt(rms / SIZE);
+  if (rms < 0.01) return null;
+
+  let lastCorrelation = 1;
+  for (let offset = 0; offset < MAX_SAMPLES; offset++) {
+    let correlation = 0;
+    for (let i = 0; i < MAX_SAMPLES; i++) {
+      correlation += Math.abs((buf[i]) - (buf[i + offset]));
+    }
+    correlation = 1 - (correlation / MAX_SAMPLES);
+    if (correlation > 0.9 && correlation > lastCorrelation) {
+      bestCorrelation = correlation;
+      bestOffset = offset;
+    } else if (correlation < lastCorrelation) {
+      if (bestCorrelation > 0.01) {
+        const freq = sampleRate / bestOffset;
+        return freq;
+      }
+    }
+    lastCorrelation = correlation;
+  }
+  if (bestCorrelation > 0.01) {
+    return sampleRate / bestOffset;
+  }
+  return null;
+}
+
+function detectKeys(hist) {
+  const scores = {};
+  const sum = hist.reduce((a, b) => a + b, 0) || 1;
+  const norm = hist.map(v => v / sum);
+  for (let i = 0; i < 12; i++) {
+    let majorScore = 0;
+    let minorScore = 0;
+    for (let j = 0; j < 12; j++) {
+      majorScore += norm[j] * majorProfile[(12 + j - i) % 12];
+      minorScore += norm[j] * minorProfile[(12 + j - i) % 12];
+    }
+    scores[`${noteNames[i]} Major`] = majorScore;
+    scores[`${noteNames[i]} Minor`] = minorScore;
+  }
+  const total = Object.values(scores).reduce((a, b) => a + b, 0) || 1;
+  for (const key in scores) {
+    scores[key] = (scores[key] / total) * 100;
+  }
+  return scores;
+}
+
+function displayResults(scores) {
+  resultsDiv.innerHTML = '';
+  const entries = Object.entries(scores).sort((a, b) => b[1] - a[1]);
+  const topKey = entries[0][0];
+  entries.forEach(([key, val]) => {
+    const bar = document.createElement('div');
+    bar.className = 'bar';
+    bar.style.width = val.toFixed(2) + '%';
+    const label = document.createElement('span');
+    label.textContent = `${key}: ${val.toFixed(2)}%`;
+    if (key === topKey) {
+      label.classList.add('top-key');
+      bar.style.background = 'rgba(100,51,162,0.8)';
+    }
+    bar.appendChild(label);
+    resultsDiv.appendChild(bar);
+  });
+}
+
+function startVisualizer() {
+  if (!audioCtx) audioCtx = new (window.AudioContext || window.webkitAudioContext)();
+  if (source) source.disconnect();
+  source = audioCtx.createMediaElementSource(audio);
+  analyser = audioCtx.createAnalyser();
+  analyser.fftSize = 2048;
+  source.connect(analyser);
+  analyser.connect(audioCtx.destination);
+  draw();
+}
+
+function draw() {
+  const width = canvas.width = canvas.offsetWidth;
+  const height = canvas.height = canvas.offsetHeight;
+  const bufferLength = analyser.frequencyBinCount;
+  const dataArray = new Uint8Array(bufferLength);
+  animationId = requestAnimationFrame(draw);
+  analyser.getByteFrequencyData(dataArray);
+  ctx.clearRect(0, 0, width, height);
+  let x = 0;
+  const barWidth = (width / bufferLength) * 2.5;
+  for (let i = 0; i < bufferLength; i++) {
+    const barHeight = dataArray[i] / 255 * height;
+    ctx.fillStyle = `rgba(100,51,162,${barHeight / height})`;
+    ctx.fillRect(x, height - barHeight, barWidth, barHeight);
+    x += barWidth + 1;
+  }
+}
+
+function stopVisualizer() {
+  cancelAnimationFrame(animationId);
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+  if (source) source.disconnect();
+}
+
+function resetAll() {
+  stopVisualizer();
+  if (audio) {
+    audio.pause();
+    audio.currentTime = 0;
+    audio.removeAttribute('src');
+    audio.load();
+  }
+  fileInput.value = '';
+  resultsDiv.innerHTML = '';
+  pitchHistogram = new Array(12).fill(0);
+}

--- a/style.css
+++ b/style.css
@@ -1,0 +1,78 @@
+body {
+  background: #0a0a0f;
+  color: #eee;
+  font-family: Arial, Helvetica, sans-serif;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+  margin: 0;
+}
+
+.container {
+  text-align: center;
+  width: 80%;
+  max-width: 900px;
+}
+
+h1 {
+  color: rgb(100, 51, 162);
+  text-shadow: 0 0 10px rgb(100, 51, 162), 0 0 20px rgb(100, 51, 162);
+}
+
+#audioFile {
+  margin: 1rem 0;
+}
+
+#visualizer {
+  width: 100%;
+  height: 200px;
+  background: #111;
+  border: 2px solid rgb(100, 51, 162);
+  box-shadow: 0 0 10px rgb(100, 51, 162);
+}
+
+#results {
+  margin-top: 1rem;
+}
+
+.bar {
+  height: 20px;
+  margin: 4px 0;
+  background: rgba(100,51,162,0.3);
+  box-shadow: 0 0 5px rgb(100, 51, 162);
+  transition: width 0.6s ease;
+}
+
+.bar span {
+  position: relative;
+  top: -22px;
+  font-size: 0.9rem;
+}
+
+.top-key {
+  font-weight: bold;
+  font-size: 1.2rem;
+  text-shadow: 0 0 10px rgb(100, 51, 162), 0 0 20px rgb(100, 51, 162), 0 0 30px rgb(100, 51, 162);
+}
+
+#resetButton {
+  margin-top: 1rem;
+  padding: 0.5rem 1rem;
+  background: rgb(100, 51, 162);
+  border: none;
+  color: #fff;
+  cursor: pointer;
+  box-shadow: 0 0 10px rgb(100, 51, 162);
+  transition: background 0.3s ease;
+}
+
+#resetButton:hover {
+  background: rgb(130, 81, 192);
+}
+
+@media (max-width: 600px) {
+  #visualizer {
+    height: 150px;
+  }
+}


### PR DESCRIPTION
## Summary
- create neon-dark web UI for music key detection
- analyze uploaded audio to compute key distribution and highlight dominant key
- add animated waveform visualizer and reset behavior

## Testing
- `npm test` (fails: Could not read package.json)

------
https://chatgpt.com/codex/tasks/task_e_688ba9e019548323a64f803d68ff819c