### PR TITLE
feat: build advanced audio analysis dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,16 @@
-# Neon Key Detector
+# Neon Audio Lab
 
-A vanilla JavaScript web application that analyzes an uploaded audio file and estimates the distribution of musical keys throughout the track. It visualizes key percentages with a glowing bar chart and an animated neon waveform synced to playback.
+A vanilla JavaScript audio analysis dashboard that works entirely in the browser. Drop an audio file to inspect musical keys, BPM, loudness and more. All graphics are rendered with the Canvas API and styled with a neon dark theme.
 
 ## Features
-- Upload audio files (`.mp3`, `.wav`, etc.).
-- Detects percentage of each major and minor key using the Web Audio API.
-- Highlights the most prominent key.
-- Animated canvas visualizer with a purple neon theme.
-- Reset button clears results and allows a new upload.
+- Drag & drop audio upload
+- Key distribution bar chart
+- Dominant note cloud
+- Estimated BPM meter
+- Dynamic range meter
+- Loudness over time graph
+- Frequency band energy (low/mid/high)
+- Animated waveform visualization
+- Reset button clears all results
 
 Open `index.html` in a modern browser to use the app.

--- a/index.html
+++ b/index.html
@@ -3,17 +3,30 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Neon Key Detector</title>
+  <title>Neon Audio Lab</title>
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>
-  <div class="container">
-    <h1>Music Key Detector</h1>
-    <input type="file" id="audioFile" accept="audio/*" />
-    <canvas id="visualizer"></canvas>
-    <div id="results"></div>
-    <button id="resetButton">Reset</button>
-    <audio id="audio" controls></audio>
+  <div id="app">
+    <h1>Neon Audio Lab</h1>
+    <div id="dropZone" class="glow">Drop Audio File or Click to Upload</div>
+    <input type="file" id="fileInput" accept="audio/*" hidden />
+    <canvas id="waveCanvas"></canvas>
+    <div id="panels">
+      <canvas id="keyCanvas" class="panel"></canvas>
+      <div id="bpmMeter" class="panel"></div>
+      <div id="noteCloud" class="panel"></div>
+      <canvas id="eqCanvas" class="panel"></canvas>
+      <div id="dynamicRange" class="panel">
+        <div class="bar"></div>
+        <div class="marker min"></div>
+        <div class="marker max"></div>
+        <span class="label"></span>
+      </div>
+      <canvas id="loudnessCanvas" class="panel"></canvas>
+    </div>
+    <div id="durationLabel"></div>
+    <button id="resetBtn">Reset</button>
   </div>
   <script src="script.js"></script>
 </body>

--- a/style.css
+++ b/style.css
@@ -1,78 +1,129 @@
+:root {
+  --accent: rgb(100, 51, 162);
+}
+
 body {
-  background: #0a0a0f;
+  background: #09090d;
   color: #eee;
-  font-family: Arial, Helvetica, sans-serif;
+  margin: 0;
+  font-family: Arial, sans-serif;
   display: flex;
   justify-content: center;
-  align-items: center;
-  min-height: 100vh;
-  margin: 0;
 }
 
-.container {
+#app {
+  width: 90%;
+  max-width: 1000px;
   text-align: center;
-  width: 80%;
-  max-width: 900px;
 }
 
-h1 {
-  color: rgb(100, 51, 162);
-  text-shadow: 0 0 10px rgb(100, 51, 162), 0 0 20px rgb(100, 51, 162);
+.glow {
+  border: 2px dashed var(--accent);
+  border-radius: 10px;
+  box-shadow: 0 0 10px var(--accent);
 }
 
-#audioFile {
-  margin: 1rem 0;
+#dropZone {
+  padding: 30px;
+  margin: 20px 0;
+  cursor: pointer;
 }
 
-#visualizer {
+#dropZone.hover {
+  background: rgba(100, 51, 162, 0.2);
+}
+
+#waveCanvas {
   width: 100%;
   height: 200px;
+}
+
+#panels {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 20px;
+  justify-content: center;
+}
+
+.panel {
   background: #111;
-  border: 2px solid rgb(100, 51, 162);
-  box-shadow: 0 0 10px rgb(100, 51, 162);
-}
-
-#results {
-  margin-top: 1rem;
-}
-
-.bar {
-  height: 20px;
-  margin: 4px 0;
-  background: rgba(100,51,162,0.3);
-  box-shadow: 0 0 5px rgb(100, 51, 162);
-  transition: width 0.6s ease;
-}
-
-.bar span {
+  border: 1px solid var(--accent);
+  box-shadow: 0 0 10px rgba(100, 51, 162, 0.5);
   position: relative;
-  top: -22px;
-  font-size: 0.9rem;
+  flex: 1 1 300px;
+  padding: 10px;
+  min-height: 150px;
 }
 
-.top-key {
-  font-weight: bold;
-  font-size: 1.2rem;
-  text-shadow: 0 0 10px rgb(100, 51, 162), 0 0 20px rgb(100, 51, 162), 0 0 30px rgb(100, 51, 162);
+#bpmMeter {
+  font-size: 40px;
+  line-height: 150px;
+  animation: none;
 }
 
-#resetButton {
-  margin-top: 1rem;
-  padding: 0.5rem 1rem;
-  background: rgb(100, 51, 162);
+@keyframes pulse {
+  0% { transform: scale(1); }
+  50% { transform: scale(1.1); }
+  100% { transform: scale(1); }
+}
+
+#noteCloud {
+  overflow: hidden;
+}
+
+#noteCloud span {
+  position: absolute;
+  color: var(--accent);
+  text-shadow: 0 0 10px var(--accent);
+}
+
+#eqCanvas, #keyCanvas, #loudnessCanvas {
+  width: 100%;
+  height: 150px;
+}
+
+#dynamicRange {
+  height: 100px;
+}
+
+#dynamicRange .bar {
+  position: absolute;
+  top: 50%;
+  height: 4px;
+  background: var(--accent);
+  box-shadow: 0 0 10px var(--accent);
+}
+
+#dynamicRange .marker {
+  position: absolute;
+  top: calc(50% - 6px);
+  width: 4px;
+  height: 16px;
+  background: #fff;
+}
+
+#dynamicRange .label {
+  position: absolute;
+  top: 60%;
+  width: 100%;
+  font-size: 12px;
+}
+
+#resetBtn {
+  background: var(--accent);
   border: none;
+  padding: 10px 20px;
+  margin: 20px auto;
   color: #fff;
+  border-radius: 5px;
+  box-shadow: 0 0 10px var(--accent);
   cursor: pointer;
-  box-shadow: 0 0 10px rgb(100, 51, 162);
-  transition: background 0.3s ease;
 }
 
-#resetButton:hover {
-  background: rgb(130, 81, 192);
+#resetBtn:hover {
+  box-shadow: 0 0 20px var(--accent);
 }
 
-@media (max-width: 600px) {
-  #visualizer {
-    height: 150px;
-  }
+#durationLabel {
+  margin-top: 10px;
 }


### PR DESCRIPTION
## Summary
- replace previous app with neon-themed audio analysis dashboard using pure HTML, CSS and JavaScript
- analyze uploaded audio for key distribution, dominant notes, BPM, loudness, dynamic range and EQ band energy
- visualize results with waveform animation, bar charts, BPM meter, note cloud, EQ and loudness graphs plus reset functionality

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688bac953ca88323b7c7d448c64f5809