### PR TITLE
feat: add loading overlay and improve note cloud

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,6 +28,10 @@
     <div id="durationLabel"></div>
     <button id="resetBtn">Reset</button>
   </div>
+  <div id="loading" class="hidden">
+    <div>Analyzing...</div>
+    <div class="progress"><div class="bar"></div></div>
+  </div>
   <script src="script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -9,6 +9,7 @@ const bpmMeter = document.getElementById('bpmMeter');
 const dynamicRangeDiv = document.getElementById('dynamicRange');
 const durationLabel = document.getElementById('durationLabel');
 const resetBtn = document.getElementById('resetBtn');
+const loadingOverlay = document.getElementById('loading');
 const noteNames = ['C','C#','D','D#','E','F','F#','G','G#','A','A#','B'];
 let waveAnimation;
 
@@ -35,12 +36,14 @@ resetBtn.addEventListener('click', resetAll);
 
 function handleFile(file) {
   if (!file) return;
+  loadingOverlay.classList.remove('hidden');
   const reader = new FileReader();
   reader.onload = async e => {
     const arrayBuffer = e.target.result;
     const audioCtx = new (window.AudioContext || window.webkitAudioContext)();
     const audioBuffer = await audioCtx.decodeAudioData(arrayBuffer);
     analyzeBuffer(audioBuffer);
+    loadingOverlay.classList.add('hidden');
   };
   reader.readAsArrayBuffer(file);
 }
@@ -219,8 +222,6 @@ function showNotes(notes) {
     span.textContent = name;
     const size = 16 + (val / max) * 40;
     span.style.fontSize = size + 'px';
-    span.style.left = Math.random() * 80 + '%';
-    span.style.top = Math.random() * 80 + '%';
     noteCloud.appendChild(span);
   });
 }
@@ -294,4 +295,5 @@ function resetAll() {
   dynamicRangeDiv.querySelector('.label').textContent = '';
   durationLabel.textContent = '';
   fileInput.value = '';
+  loadingOverlay.classList.add('hidden');
 }

--- a/style.css
+++ b/style.css
@@ -68,13 +68,18 @@ body {
 }
 
 #noteCloud {
-  overflow: hidden;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  justify-content: center;
+  align-content: flex-start;
+  overflow: auto;
 }
 
 #noteCloud span {
-  position: absolute;
   color: var(--accent);
   text-shadow: 0 0 10px var(--accent);
+  margin: 5px;
 }
 
 #eqCanvas, #keyCanvas, #loudnessCanvas {
@@ -126,4 +131,44 @@ body {
 
 #durationLabel {
   margin-top: 10px;
+}
+
+#loading {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.7);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+#loading.hidden {
+  display: none;
+}
+
+#loading .progress {
+  width: 50%;
+  max-width: 300px;
+  height: 10px;
+  background: #333;
+  margin-top: 10px;
+  overflow: hidden;
+  border-radius: 5px;
+}
+
+#loading .progress .bar {
+  height: 100%;
+  width: 0;
+  background: var(--accent);
+  animation: loading 2s infinite;
+}
+
+@keyframes loading {
+  from { width: 0; }
+  to { width: 100%; }
 }


### PR DESCRIPTION
## Summary
- improve noteCloud layout by using flex wrap for readability
- add animated loading overlay with progress bar during audio analysis

## Testing
- `node --check script.js && echo 'syntax ok'`


------
https://chatgpt.com/codex/tasks/task_e_688bafeb06ac832399d0d30f86958270